### PR TITLE
Throw exception for error, same as 'read'

### DIFF
--- a/r2dbc-migrate-core/src/main/java/name/nkonev/r2dbc/migrate/core/FileReader.java
+++ b/r2dbc-migrate-core/src/main/java/name/nkonev/r2dbc/migrate/core/FileReader.java
@@ -21,7 +21,7 @@ public abstract class FileReader {
                     BaseStream::close
             );
         } catch (Exception e) {
-            return Flux.error(new RuntimeException("Error during get resources from '" + resource + "'", e));
+            throw new RuntimeException("Error during get resources from '" + resource + "': ", e);
         }
     }
 
@@ -29,7 +29,7 @@ public abstract class FileReader {
         try (InputStream inputStream = resource.getInputStream()) {
             return StreamUtils.copyToString(inputStream, fileCharset);
         } catch (IOException e) {
-            throw new RuntimeException("Error during reading file '" + resource.getFilename() + "'", e);
+            throw new RuntimeException("Error during reading file '" + resource.getFilename() + "': ", e);
         }
     }
 


### PR DESCRIPTION
Hello,
this is just a suggestion(or question), so just ignore if this is inappropriate.
Seems `read` and `readChunked` are similar(only one read file and other read byte stream), but `readChunked` are returning flux with error.
Will there be a problem if just throw exception and stop at `catch` event?

