### PR TITLE
Feature/semantic versions

### DIFF
--- a/r2dbc-migrate-core/src/main/java/name/nkonev/r2dbc/migrate/core/FilenameParser.java
+++ b/r2dbc-migrate-core/src/main/java/name/nkonev/r2dbc/migrate/core/FilenameParser.java
@@ -10,6 +10,8 @@ public abstract class FilenameParser {
 
     private static final String DECIMAL_POINT = ".";
 
+    private static final String UNDERSCORE = "_";
+
     public static class MigrationInfo {
         private String version;
         private String description;
@@ -87,12 +89,14 @@ public abstract class FilenameParser {
                 .orElseThrow(() -> new RuntimeException(String.format("Invalid version number %s", vPart)));
     }
 
-    public static Double findDoubleVersion(final String version) {
+    public static Double findDoubleVersion(final String versionString) {
+        final String version = versionString.replace(UNDERSCORE, DECIMAL_POINT);
+
         return Optional.of(version)
                 .filter(val -> val.contains(DECIMAL_POINT))
                 .filter(val -> val.replace(DECIMAL_POINT, "").length() - val.length() == -2)
                 .map(val -> val.indexOf(DECIMAL_POINT, val.indexOf(DECIMAL_POINT) + 1))
-                .map(val -> version.substring(0, val - 1) + version.substring(val + 1, version.length()))
+                .map(val -> version.substring(0, val) + version.substring(val + 1))
                 .map(Double::parseDouble)
                 .orElseGet(() -> Double.parseDouble(version));
     }

--- a/r2dbc-migrate-core/src/main/java/name/nkonev/r2dbc/migrate/core/FilenameParser.java
+++ b/r2dbc-migrate-core/src/main/java/name/nkonev/r2dbc/migrate/core/FilenameParser.java
@@ -2,8 +2,13 @@ package name.nkonev.r2dbc.migrate.core;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public abstract class FilenameParser {
+
+    private static final String V = "V";
+
+    private static final String DECIMAL_POINT = ".";
 
     public static class MigrationInfo {
         private int version;
@@ -11,7 +16,7 @@ public abstract class FilenameParser {
         private boolean splitByLine;
         private boolean transactional;
 
-        public MigrationInfo(int version, String description, boolean splitByLine, boolean transactional) {
+        public MigrationInfo(String version, String description, boolean splitByLine, boolean transactional) {
             this.version = version;
             this.description = description;
             this.splitByLine = splitByLine;
@@ -22,7 +27,7 @@ public abstract class FilenameParser {
             return description;
         }
 
-        public int getVersion() {
+        public String getVersion() {
             return version;
         }
 
@@ -44,9 +49,21 @@ public abstract class FilenameParser {
                     ", transactional=" + transactional +
                     '}';
         }
+
+        public Double findDoubleVersion() {
+            return Optional.of(version)
+                    .filter(val -> val.contains(DECIMAL_POINT))
+                    .filter(val -> val.replace(DECIMAL_POINT, "").length() - val.length() == -2)
+                    .map(val -> val.indexOf(DECIMAL_POINT, val.indexOf(DECIMAL_POINT) + 1))
+                    .map(val -> version.substring(0, val - 1) + version.substring(val + 1, version.length()))
+                    .map(Double::parseDouble)
+                    .orElseGet(() -> Double.parseDouble(version));
+        }
+
     }
 
-    public static MigrationInfo getMigrationInfo(String filename) {
+    public static MigrationInfo getMigrationInfo(String filename) throws RuntimeException
+    {
         final String sql = ".sql";
         if (filename == null || !filename.endsWith(sql)) {
             throw new RuntimeException("File name should ends with " + sql);
@@ -67,9 +84,11 @@ public abstract class FilenameParser {
         }
     }
 
-    private static int getVersion(String vPart) {
-        String v = vPart.replace("V", "");
-        return Integer.parseInt(v);
+    private static String getVersion(String vPart)
+    {
+        return Optional.of(vPart)
+                .map(val -> val.substring(val.indexOf(V) + 1))
+                .orElseThrow(() -> new RuntimeException(String.format("Invalid version number %s", vPart)));
     }
 
     private static String getDescription(String descriptionPart) {

--- a/r2dbc-migrate-core/src/main/java/name/nkonev/r2dbc/migrate/core/FilenameParser.java
+++ b/r2dbc-migrate-core/src/main/java/name/nkonev/r2dbc/migrate/core/FilenameParser.java
@@ -11,16 +11,18 @@ public abstract class FilenameParser {
     private static final String DECIMAL_POINT = ".";
 
     public static class MigrationInfo {
-        private int version;
+        private String version;
         private String description;
         private boolean splitByLine;
         private boolean transactional;
+        private Double doubleVersion;
 
         public MigrationInfo(String version, String description, boolean splitByLine, boolean transactional) {
             this.version = version;
             this.description = description;
             this.splitByLine = splitByLine;
             this.transactional = transactional;
+            this.doubleVersion = findDoubleVersion(version);
         }
 
         public String getDescription() {
@@ -29,6 +31,10 @@ public abstract class FilenameParser {
 
         public String getVersion() {
             return version;
+        }
+
+        public Double getDoubleVersion() {
+            return doubleVersion;
         }
 
         public boolean isSplitByLine() {
@@ -48,16 +54,6 @@ public abstract class FilenameParser {
                     ", splitByLine=" + splitByLine +
                     ", transactional=" + transactional +
                     '}';
-        }
-
-        public Double findDoubleVersion() {
-            return Optional.of(version)
-                    .filter(val -> val.contains(DECIMAL_POINT))
-                    .filter(val -> val.replace(DECIMAL_POINT, "").length() - val.length() == -2)
-                    .map(val -> val.indexOf(DECIMAL_POINT, val.indexOf(DECIMAL_POINT) + 1))
-                    .map(val -> version.substring(0, val - 1) + version.substring(val + 1, version.length()))
-                    .map(Double::parseDouble)
-                    .orElseGet(() -> Double.parseDouble(version));
         }
 
     }
@@ -89,6 +85,16 @@ public abstract class FilenameParser {
         return Optional.of(vPart)
                 .map(val -> val.substring(val.indexOf(V) + 1))
                 .orElseThrow(() -> new RuntimeException(String.format("Invalid version number %s", vPart)));
+    }
+
+    public static Double findDoubleVersion(final String version) {
+        return Optional.of(version)
+                .filter(val -> val.contains(DECIMAL_POINT))
+                .filter(val -> val.replace(DECIMAL_POINT, "").length() - val.length() == -2)
+                .map(val -> val.indexOf(DECIMAL_POINT, val.indexOf(DECIMAL_POINT) + 1))
+                .map(val -> version.substring(0, val - 1) + version.substring(val + 1, version.length()))
+                .map(Double::parseDouble)
+                .orElseGet(() -> Double.parseDouble(version));
     }
 
     private static String getDescription(String descriptionPart) {

--- a/r2dbc-migrate-core/src/main/java/name/nkonev/r2dbc/migrate/core/R2dbcMigrate.java
+++ b/r2dbc-migrate-core/src/main/java/name/nkonev/r2dbc/migrate/core/R2dbcMigrate.java
@@ -219,7 +219,7 @@ public abstract class R2dbcMigrate {
         List<Tuple2<MigrateResource, MigrationInfo>> sortedResources = allResources.stream().sorted((o1, o2) -> {
             MigrationInfo migrationInfo1 = o1.getT2();
             MigrationInfo migrationInvo2 = o2.getT2();
-            return Integer.compare(migrationInfo1.getVersion(), migrationInvo2.getVersion());
+            return Double.compare(migrationInfo1.findDoubleVersion(), migrationInvo2.findDoubleVersion());
         }).peek(objects -> {
             LOGGER.debug("From {} parsed metadata {}", objects.getT1(), objects.getT2());
         }).collect(Collectors.toList());
@@ -254,7 +254,7 @@ public abstract class R2dbcMigrate {
                     LOGGER.info("Database version is {}", currentVersion);
 
                     return getFileResources(properties, resourceReader).log("R2dbcMigrateRequestingMigrationFiles", Level.FINE)
-                        .filter(objects -> objects.getT2().getVersion() > currentVersion)
+                        .filter(objects -> objects.getT2().findDoubleVersion() > currentVersion)
                         // We need to guarantee sequential queries for BEGIN; STATEMENTS; COMMIT; wrappings for PostgreSQL
                         .concatMap(tuple2 ->
                                 makeMigration(connection, properties, tuple2).log("R2dbcMigrateMakeMigrationWork", Level.FINE)

--- a/r2dbc-migrate-core/src/main/java/name/nkonev/r2dbc/migrate/core/R2dbcMigrate.java
+++ b/r2dbc-migrate-core/src/main/java/name/nkonev/r2dbc/migrate/core/R2dbcMigrate.java
@@ -219,7 +219,7 @@ public abstract class R2dbcMigrate {
         List<Tuple2<MigrateResource, MigrationInfo>> sortedResources = allResources.stream().sorted((o1, o2) -> {
             MigrationInfo migrationInfo1 = o1.getT2();
             MigrationInfo migrationInvo2 = o2.getT2();
-            return Double.compare(migrationInfo1.findDoubleVersion(), migrationInvo2.findDoubleVersion());
+            return Double.compare(migrationInfo1.getDoubleVersion(), migrationInvo2.getDoubleVersion());
         }).peek(objects -> {
             LOGGER.debug("From {} parsed metadata {}", objects.getT1(), objects.getT2());
         }).collect(Collectors.toList());
@@ -254,7 +254,7 @@ public abstract class R2dbcMigrate {
                     LOGGER.info("Database version is {}", currentVersion);
 
                     return getFileResources(properties, resourceReader).log("R2dbcMigrateRequestingMigrationFiles", Level.FINE)
-                        .filter(objects -> objects.getT2().findDoubleVersion() > currentVersion)
+                        .filter(objects -> objects.getT2().getDoubleVersion() > currentVersion)
                         // We need to guarantee sequential queries for BEGIN; STATEMENTS; COMMIT; wrappings for PostgreSQL
                         .concatMap(tuple2 ->
                                 makeMigration(connection, properties, tuple2).log("R2dbcMigrateMakeMigrationWork", Level.FINE)

--- a/r2dbc-migrate-core/src/test/java/name/nkonev/r2dbc/migrate/core/AbstractMysqlLikeTestcontainersTest.java
+++ b/r2dbc-migrate-core/src/test/java/name/nkonev/r2dbc/migrate/core/AbstractMysqlLikeTestcontainersTest.java
@@ -144,7 +144,7 @@ public abstract class AbstractMysqlLikeTestcontainersTest extends LogCaptureable
             connection -> Flux.from(connection.createStatement("select * from `my scheme`.`my migrations` order by id").execute())
                 .flatMap(o -> o.map((row, rowMetadata) -> {
                     return new MigrationInfo(
-                        row.get("id", Integer.class),
+                        String.valueOf(row.get("id", Integer.class)),
                         row.get("description", String.class),
                         false,
                         false

--- a/r2dbc-migrate-core/src/test/java/name/nkonev/r2dbc/migrate/core/FilenameParserTest.java
+++ b/r2dbc-migrate-core/src/test/java/name/nkonev/r2dbc/migrate/core/FilenameParserTest.java
@@ -10,7 +10,31 @@ class FilenameParserTest {
     void testSplit() {
         String s = "V5__create_customers__split.sql";
         FilenameParser.MigrationInfo migrationInfo = FilenameParser.getMigrationInfo(s);
-        Assertions.assertEquals(5, migrationInfo.getVersion());
+        Assertions.assertEquals("5", migrationInfo.getVersion());
+        Assertions.assertEquals(5.0, migrationInfo.findDoubleVersion());
+        Assertions.assertEquals("create customers", migrationInfo.getDescription());
+        Assertions.assertTrue(migrationInfo.isSplitByLine());
+        Assertions.assertTrue(migrationInfo.isTransactional());
+    }
+
+    @Test
+    void testItParsesSemanticVersions() {
+        String s = "V1.2.3__create_customers__split.sql";
+        FilenameParser.MigrationInfo migrationInfo = FilenameParser.getMigrationInfo(s);
+        Assertions.assertEquals("1.2.3", migrationInfo.getVersion());
+        Assertions.assertEquals(1.23, migrationInfo.findDoubleVersion());
+        Assertions.assertEquals("create customers", migrationInfo.getDescription());
+        Assertions.assertEquals("create customers", migrationInfo.getDescription());
+        Assertions.assertTrue(migrationInfo.isSplitByLine());
+        Assertions.assertTrue(migrationInfo.isTransactional());
+    }
+
+    @Test
+    void testItParsesVersionsWithSingleDecimals() {
+        String s = "V1.2__create_customers__split.sql";
+        FilenameParser.MigrationInfo migrationInfo = FilenameParser.getMigrationInfo(s);
+        Assertions.assertEquals("1.2", migrationInfo.getVersion());
+        Assertions.assertEquals(1.2, migrationInfo.findDoubleVersion());
         Assertions.assertEquals("create customers", migrationInfo.getDescription());
         Assertions.assertTrue(migrationInfo.isSplitByLine());
         Assertions.assertTrue(migrationInfo.isTransactional());
@@ -20,7 +44,8 @@ class FilenameParserTest {
     void testSplitNontransactional() {
         String s = "V5__create_customers__split,nontransactional.sql";
         FilenameParser.MigrationInfo migrationInfo = FilenameParser.getMigrationInfo(s);
-        Assertions.assertEquals(5, migrationInfo.getVersion());
+        Assertions.assertEquals("5", migrationInfo.getVersion());
+        Assertions.assertEquals(5.0, migrationInfo.findDoubleVersion());
         Assertions.assertEquals("create customers", migrationInfo.getDescription());
         Assertions.assertTrue(migrationInfo.isSplitByLine());
         Assertions.assertFalse(migrationInfo.isTransactional());
@@ -30,7 +55,8 @@ class FilenameParserTest {
     void testNontransactional() {
         String s = "V5__create_customers__nontransactional.sql";
         FilenameParser.MigrationInfo migrationInfo = FilenameParser.getMigrationInfo(s);
-        Assertions.assertEquals(5, migrationInfo.getVersion());
+        Assertions.assertEquals("5", migrationInfo.getVersion());
+        Assertions.assertEquals(5.0, migrationInfo.findDoubleVersion());
         Assertions.assertEquals("create customers", migrationInfo.getDescription());
         Assertions.assertFalse(migrationInfo.isSplitByLine());
         Assertions.assertFalse(migrationInfo.isTransactional());
@@ -40,7 +66,8 @@ class FilenameParserTest {
     void test() {
         String s = "V5__create_customers.sql";
         FilenameParser.MigrationInfo migrationInfo = FilenameParser.getMigrationInfo(s);
-        Assertions.assertEquals(5, migrationInfo.getVersion());
+        Assertions.assertEquals("5", migrationInfo.getVersion());
+        Assertions.assertEquals(5.0, migrationInfo.findDoubleVersion());
         Assertions.assertEquals("create customers", migrationInfo.getDescription());
         Assertions.assertFalse(migrationInfo.isSplitByLine());
         Assertions.assertTrue(migrationInfo.isTransactional());

--- a/r2dbc-migrate-core/src/test/java/name/nkonev/r2dbc/migrate/core/FilenameParserTest.java
+++ b/r2dbc-migrate-core/src/test/java/name/nkonev/r2dbc/migrate/core/FilenameParserTest.java
@@ -11,7 +11,7 @@ class FilenameParserTest {
         String s = "V5__create_customers__split.sql";
         FilenameParser.MigrationInfo migrationInfo = FilenameParser.getMigrationInfo(s);
         Assertions.assertEquals("5", migrationInfo.getVersion());
-        Assertions.assertEquals(5.0, migrationInfo.findDoubleVersion());
+        Assertions.assertEquals(5.0, migrationInfo.getDoubleVersion());
         Assertions.assertEquals("create customers", migrationInfo.getDescription());
         Assertions.assertTrue(migrationInfo.isSplitByLine());
         Assertions.assertTrue(migrationInfo.isTransactional());
@@ -22,7 +22,7 @@ class FilenameParserTest {
         String s = "V1.2.3__create_customers__split.sql";
         FilenameParser.MigrationInfo migrationInfo = FilenameParser.getMigrationInfo(s);
         Assertions.assertEquals("1.2.3", migrationInfo.getVersion());
-        Assertions.assertEquals(1.23, migrationInfo.findDoubleVersion());
+        Assertions.assertEquals(1.23, migrationInfo.getDoubleVersion());
         Assertions.assertEquals("create customers", migrationInfo.getDescription());
         Assertions.assertEquals("create customers", migrationInfo.getDescription());
         Assertions.assertTrue(migrationInfo.isSplitByLine());
@@ -34,7 +34,7 @@ class FilenameParserTest {
         String s = "V1.2__create_customers__split.sql";
         FilenameParser.MigrationInfo migrationInfo = FilenameParser.getMigrationInfo(s);
         Assertions.assertEquals("1.2", migrationInfo.getVersion());
-        Assertions.assertEquals(1.2, migrationInfo.findDoubleVersion());
+        Assertions.assertEquals(1.2, migrationInfo.getDoubleVersion());
         Assertions.assertEquals("create customers", migrationInfo.getDescription());
         Assertions.assertTrue(migrationInfo.isSplitByLine());
         Assertions.assertTrue(migrationInfo.isTransactional());
@@ -45,7 +45,7 @@ class FilenameParserTest {
         String s = "V5__create_customers__split,nontransactional.sql";
         FilenameParser.MigrationInfo migrationInfo = FilenameParser.getMigrationInfo(s);
         Assertions.assertEquals("5", migrationInfo.getVersion());
-        Assertions.assertEquals(5.0, migrationInfo.findDoubleVersion());
+        Assertions.assertEquals(5.0, migrationInfo.getDoubleVersion());
         Assertions.assertEquals("create customers", migrationInfo.getDescription());
         Assertions.assertTrue(migrationInfo.isSplitByLine());
         Assertions.assertFalse(migrationInfo.isTransactional());
@@ -56,7 +56,7 @@ class FilenameParserTest {
         String s = "V5__create_customers__nontransactional.sql";
         FilenameParser.MigrationInfo migrationInfo = FilenameParser.getMigrationInfo(s);
         Assertions.assertEquals("5", migrationInfo.getVersion());
-        Assertions.assertEquals(5.0, migrationInfo.findDoubleVersion());
+        Assertions.assertEquals(5.0, migrationInfo.getDoubleVersion());
         Assertions.assertEquals("create customers", migrationInfo.getDescription());
         Assertions.assertFalse(migrationInfo.isSplitByLine());
         Assertions.assertFalse(migrationInfo.isTransactional());
@@ -67,7 +67,7 @@ class FilenameParserTest {
         String s = "V5__create_customers.sql";
         FilenameParser.MigrationInfo migrationInfo = FilenameParser.getMigrationInfo(s);
         Assertions.assertEquals("5", migrationInfo.getVersion());
-        Assertions.assertEquals(5.0, migrationInfo.findDoubleVersion());
+        Assertions.assertEquals(5.0, migrationInfo.getDoubleVersion());
         Assertions.assertEquals("create customers", migrationInfo.getDescription());
         Assertions.assertFalse(migrationInfo.isSplitByLine());
         Assertions.assertTrue(migrationInfo.isTransactional());

--- a/r2dbc-migrate-core/src/test/java/name/nkonev/r2dbc/migrate/core/FilenameParserTest.java
+++ b/r2dbc-migrate-core/src/test/java/name/nkonev/r2dbc/migrate/core/FilenameParserTest.java
@@ -30,10 +30,33 @@ class FilenameParserTest {
     }
 
     @Test
+    void testItParsesSemanticVersionsWithUnderscores() {
+        String s = "V1_2_3__create_customers__split.sql";
+        FilenameParser.MigrationInfo migrationInfo = FilenameParser.getMigrationInfo(s);
+        Assertions.assertEquals("1_2_3", migrationInfo.getVersion());
+        Assertions.assertEquals(1.23, migrationInfo.getDoubleVersion());
+        Assertions.assertEquals("create customers", migrationInfo.getDescription());
+        Assertions.assertEquals("create customers", migrationInfo.getDescription());
+        Assertions.assertTrue(migrationInfo.isSplitByLine());
+        Assertions.assertTrue(migrationInfo.isTransactional());
+    }
+
+    @Test
     void testItParsesVersionsWithSingleDecimals() {
         String s = "V1.2__create_customers__split.sql";
         FilenameParser.MigrationInfo migrationInfo = FilenameParser.getMigrationInfo(s);
         Assertions.assertEquals("1.2", migrationInfo.getVersion());
+        Assertions.assertEquals(1.2, migrationInfo.getDoubleVersion());
+        Assertions.assertEquals("create customers", migrationInfo.getDescription());
+        Assertions.assertTrue(migrationInfo.isSplitByLine());
+        Assertions.assertTrue(migrationInfo.isTransactional());
+    }
+
+    @Test
+    void testItParsesVersionsWithSingleDecimalsAndUnderscores() {
+        String s = "V1_2__create_customers__split.sql";
+        FilenameParser.MigrationInfo migrationInfo = FilenameParser.getMigrationInfo(s);
+        Assertions.assertEquals("1_2", migrationInfo.getVersion());
         Assertions.assertEquals(1.2, migrationInfo.getDoubleVersion());
         Assertions.assertEquals("create customers", migrationInfo.getDescription());
         Assertions.assertTrue(migrationInfo.isSplitByLine());

--- a/r2dbc-migrate-core/src/test/java/name/nkonev/r2dbc/migrate/core/MssqlTestcontainersTest.java
+++ b/r2dbc-migrate-core/src/test/java/name/nkonev/r2dbc/migrate/core/MssqlTestcontainersTest.java
@@ -216,7 +216,7 @@ public class MssqlTestcontainersTest extends LogCaptureableTests {
             connection -> Flux.from(connection.createStatement("select * from \"my scheme\".\"my migrations\" order by id").execute())
                 .flatMap(o -> o.map((row, rowMetadata) -> {
                     return new MigrationInfo(
-                        row.get("id", Integer.class),
+                        String.valueOf(row.get("id", Integer.class)),
                         row.get("description", String.class),
                         false,
                         false

--- a/r2dbc-migrate-core/src/test/java/name/nkonev/r2dbc/migrate/core/PostgresTestcontainersTest.java
+++ b/r2dbc-migrate-core/src/test/java/name/nkonev/r2dbc/migrate/core/PostgresTestcontainersTest.java
@@ -301,7 +301,7 @@ public class PostgresTestcontainersTest extends LogCaptureableTests {
             connection -> Flux.from(connection.createStatement("select * from \"my scheme\".\"my migrations\" order by id").execute())
                 .flatMap(o -> o.map((row, rowMetadata) -> {
                     return new MigrationInfo(
-                        row.get("id", Integer.class),
+                        String.valueOf(row.get("id", Integer.class)),
                         row.get("description", String.class),
                         false,
                         false


### PR DESCRIPTION
This PR addresses issue #10 by providing support for semantic versioning when the version number is separated by dots or underscores.

I have implemented the version number as a double whilst retaining the original version string. The one issue with this is that in the comparisons of versions 1.23 would be lower that 1.23.4 which I think is fine as I can't see people having two different versioning schemes. I can do something about it if required. 